### PR TITLE
Adding setvbuf

### DIFF
--- a/stdoutredirector.cpp
+++ b/stdoutredirector.cpp
@@ -55,6 +55,8 @@ static void createWinPipe(HANDLE &hRead, HANDLE &hWrite)
 StdoutRedirector::StdoutRedirector(QObject *parent, ProcessChannels channels) :
     QObject(parent), m_channels(channels)
 {
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
 #ifdef Q_OS_WIN
     createWinPipe(hRead, hWrite);
     if (m_channels & StandardOutput)


### PR DESCRIPTION
Hello @dbzhang800 ,

Thank you for your work and for publishing StdoutRedirector, which is indeed a very nice utility code for Qt GUI applications. I would like to confirm that your solution works well on Ubuntu 18.04 and Windows 7/10 with MSYS2 (MinGW), both Qt 5. One changed is required though:

```
setvbuf(stdout, NULL, _IONBF, 0);
setvbuf(stderr, NULL, _IONBF, 0);
```

Without stream buffers set to zero as shown above, Linux is able to redirect stderr only (stdout does not work), while on Windows the redirection does not work at all.

Please consider to merge this PR, thanks!